### PR TITLE
Upgrade Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@master
+      - uses: actions/checkout@v3
 
       - uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
* checkout@v3

Note that we were pinned to `checkout@master` and there may be historical reasons for that (maybe set it and forget it motivation), but `checkout@v3` works and is consistent with other projects.